### PR TITLE
connector_flow: Fix issue where it tries to update chunk status in a broken transaction

### DIFF
--- a/connector_flow/task/abstract_task.py
+++ b/connector_flow/task/abstract_task.py
@@ -94,6 +94,7 @@ class AbstractChunkReadTask(AbstractTask):
             result = self.read_chunk(**kwargs)
             new_state = 'done'
         except:
+            self.session.env.cr.rollback()
             raise
         finally:
             chunk.write({'state': new_state})


### PR DESCRIPTION
This might happen for example if multiple workers try to execute same job at the same time. It may cause an error "could not serialize access due to concurrent update", which will abort the transaction, yet it will still call chunk.write({'state': new_state}) after that.
