### PR TITLE
The write of state will fail because of connector himself also writes…

### DIFF
--- a/connector_flow/task/abstract_task.py
+++ b/connector_flow/task/abstract_task.py
@@ -95,8 +95,6 @@ class AbstractChunkReadTask(AbstractTask):
             new_state = 'done'
         except:
             raise
-        finally:
-            chunk.write({'state': new_state})
         return result
 
     def read_chunk(self, **kwargs):


### PR DESCRIPTION
… this state. So it is not neccessary to write the state here.
