### PR TITLE
connector_flow: raise import script exception instead error of failed write

### DIFF
--- a/connector_flow/task/abstract_task.py
+++ b/connector_flow/task/abstract_task.py
@@ -17,11 +17,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
-from openerp.addons.connector.session import ConnectorSession
-from openerp import _
 import simplejson
 from base64 import b64encode, b64decode
+
+from openerp import _
+from openerp.addons.connector.session import ConnectorSession
 
 
 class AbstractTask(object):
@@ -96,7 +96,10 @@ class AbstractChunkReadTask(AbstractTask):
         except:
             raise
         finally:
-            chunk.write({'state': new_state})
+            try:
+                chunk.write({'state': new_state})
+            except:
+                pass
         return result
 
     def read_chunk(self, **kwargs):


### PR DESCRIPTION
This happens when chunk is created in synchronous mode.
PEP-8 valid imports.

Same issue #4 that can be closed.
